### PR TITLE
Removed "whois" method from Client

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -36,12 +36,6 @@ Client.prototype = {
     }, callback);
   },
 
-  whois: function(domain, callback) {
-    this._get('/whois', {
-      domain: domain,
-    }, callback);
-  },
-
   zones: function(callback) {
     this._get('/zones', {}, callback);
   },


### PR DESCRIPTION
There was no mention of it in the Readme, so nothing to change there. 