### PR TITLE
Highliting expiring domains in orange

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "domainr-search-box",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "description": "Domainr instant search box for your site",
   "homepage": "https://github.com/domainr/domainr-search-box",
   "repository": "https://github.com/domainr/domainr-search-box.git",

--- a/src/index.css
+++ b/src/index.css
@@ -94,7 +94,15 @@
 
 .domainr-results .expiring,
 .domainr-results .deleting {
-  color: #009900;
+  color: #f79a0f;
+  background-color: #fef4e7;
+}
+
+.domainr-results .expiring:hover,
+.domainr-results .deleting:hover,
+.domainr-results .expiring.selected,
+.domainr-results .deleting.selected {
+  background-color: #f2e8dc;
 }
 
 .domainr-results .expiring:after,
@@ -141,4 +149,3 @@
   left: -0.3em;
   width: 0;
 }
-


### PR DESCRIPTION
@case says "why not?" to making the https://github.com/domainr/mustang-demo/pull/107 change for this library, so here it is.

<img width="418" alt="image" src="https://user-images.githubusercontent.com/338989/32797888-f8248038-c927-11e7-9c5d-c823558af86a.png">

...and this is what it looks like with the hover or arrow key selection on the expiring line:

<img width="412" alt="image" src="https://user-images.githubusercontent.com/338989/32797922-1a64f2ea-c928-11e7-8bc6-44ea2391dada.png">
