### PR TITLE
Better styling for disallowed and invalid domains

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -64,7 +64,7 @@
   content: "available";
 }
 
-.domainr-results .pending:not(.disallowed):not(.unregistrable):not(.zone):not(.suffix):after {
+.domainr-results .pending:not(.disallowed):not(.invalid):not(.unregistrable):not(.zone):not(.suffix):after {
   content: "new";
 }
 
@@ -130,8 +130,9 @@
 
 .domainr-results .unregistrable,
 .domainr-results .disallowed,
+.domainr-results .invalid,
 .domainr-results .unknown {
-  color: #333333;
+  color: rgba(0, 0, 0, 0.3);
 }
 
 .domainr-results .tld,


### PR DESCRIPTION
Updated the styling for `disallowed` domains, such as eo.re, as seen here: 

<img width="385" alt="image" src="https://user-images.githubusercontent.com/338989/33296894-e5d7f502-d392-11e7-8999-65699b4fab69.png">

@ydnar @case Are there any other cases we want to cover? I've added support for `invalid` but I don't know any invalid domains to test on.