### PR TITLE
Show premium hint when premium

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -60,7 +60,7 @@
   background: #ddeedd;
 }
 
-.domainr-results .inactive:not(.reserved):after {
+.domainr-results .inactive:not(.reserved):not(.premium):after {
   content: "available";
 }
 


### PR DESCRIPTION
When a domain is a premium, its hint should say "premium", not "available".

@iangilman @ydnar am not sure if this is the correct fix, but wanted to take a stab at it.

Previous behavior:

<img width="350" alt="screenshot 2017-12-03 15 50 31" src="https://user-images.githubusercontent.com/20105/33530203-ebe77194-d841-11e7-93b7-127c18ec7b1e.png">

New behavior:

<img width="360" alt="screenshot 2017-12-03 15 48 03" src="https://user-images.githubusercontent.com/20105/33530196-dcd038ee-d841-11e7-9695-0c6e3cd122ff.png">
